### PR TITLE
Fix a simple typo in document and comment (contex -> context)

### DIFF
--- a/doc/bbmustache.md
+++ b/doc/bbmustache.md
@@ -65,7 +65,7 @@ option() = {key_type, atom | binary | string} | raise_on_context_miss | {escape_
 
  - key_type:
 -- Specify the type of the key in [`data/0`](#data-0). Default value is `string`.
-- raise_on_contex_miss:
+- raise_on_context_miss:
 -- If key exists in template does not exist in data, it will throw an exception (error).
 - escape_fun:
 -- Specify your own escape function.

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -111,7 +111,7 @@
                     | {escape_fun, fun((binary()) -> binary())}.
 %% - key_type:
 %%    -- Specify the type of the key in {@link data/0}. Default value is `string'.
-%% - raise_on_contex_miss:
+%% - raise_on_context_miss:
 %%    -- If key exists in template does not exist in data, it will throw an exception (error).
 %% - escape_fun:
 %%    -- Specify your own escape function.


### PR DESCRIPTION
It looks like a typo.

There is no other `contex`. :)