### PR TITLE
FIX: If there are templates that do not exist, parse does not end...

### DIFF
--- a/ct/bbmustache_SUITE.erl
+++ b/ct/bbmustache_SUITE.erl
@@ -11,11 +11,11 @@
 
          variables_ct/1, sections_ct1/1, sections_ct2/1, sections_ct3/1, sections_ct4/1,
          lambdas_ct/1, comments_ct/1, partials_ct/1, delimiter_ct/1, dot_ct/1, dot_unescape_ct/1,
-         indent_partials_ct/1
+         indent_partials_ct/1, not_found_partials_ct/1
         ]).
 -define(ALL_TEST, [variables_ct, sections_ct1, sections_ct2, sections_ct3, sections_ct4,
                    lambdas_ct, comments_ct, partials_ct, delimiter_ct, dot_ct, dot_unescape_ct,
-                   indent_partials_ct, context_stack_ct, context_stack_ct2]).
+                   indent_partials_ct, not_found_partials_ct, context_stack_ct, context_stack_ct2]).
 
 -define(config2, proplists:get_value).
 -define(debug(X), begin io:format("~p", [X]), X end).
@@ -171,6 +171,12 @@ indent_partials_ct(Config) ->
 
     Data = [{"sections", [[{"section", "1st section"}], [{"section", "2nd section"}]]}],
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
+
+not_found_partials_ct(Config) ->
+    Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"not_found_partial.mustache">>])),
+    {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"not_found_partial.result">>])),
+
+    ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))([])), ?config2(options, Config, []))).
 
 context_stack_ct(Config) ->
     Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"context.mustache">>])),

--- a/ct/bbmustache_SUITE_data/not_found_partial.mustache
+++ b/ct/bbmustache_SUITE_data/not_found_partial.mustache
@@ -1,0 +1,4 @@
+It is not_found_partial.mustache.
+begin
+  {{> does_not_exist_template}}
+end

--- a/ct/bbmustache_SUITE_data/not_found_partial.result
+++ b/ct/bbmustache_SUITE_data/not_found_partial.result
@@ -1,0 +1,3 @@
+It is not_found_partial.mustache.
+begin
+end

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -78,7 +78,10 @@
 -record(?MODULE,
         {
           data               :: [tag()],
-          partials      = [] :: [{key(), [tag()]}],
+
+          partials      = [] :: [{key(), [tag()]} | key()],
+          %% When it include key(), The key already parsed but its file does not exist.
+
           options       = [] :: [option()],
           indents       = [] :: [binary()],
           context_stack = [] :: [data()]
@@ -262,7 +265,7 @@ parse_binary_impl(State = #state{partials = [P | PartialKeys]}, Template = #?MOD
                     {State1, Data} = parse(State, Input),
                     parse_binary_impl(State1, Template#?MODULE{partials = [{P, Data} | Partials]});
                 _ ->
-                    parse_binary_impl(State#state{partials = PartialKeys}, Template#?MODULE{partials = []})
+                    parse_binary_impl(State#state{partials = PartialKeys}, Template#?MODULE{partials = [P | Partials]})
             end
     end;
 parse_binary_impl(State, Input) ->


### PR DESCRIPTION
[WIP]


It is a **serious bug**.

When you execute `bbmustache:parse_file(<<"not_found_partial.mustache">>)`, parse is never finish.

```
It is not_found_partial.mustache.
begin
  {{> does_not_exist_template}}
end
```

Behavior after fixed.
```erl
1> Template = bbmustache:parse_file(<<"not_found_partial.mustache">>).                         
{bbmustache,[{'>',<<"not_found_partial">>,<<>>}],
            [<<"does_not_exist_template">>,
             {<<"not_found_partial">>,
              [<<"It is not_found_partial.mustache.\n">>,<<"begin\n">>,
               {'>',<<"does_not_exist_template">>,<<"  ">>},
               <<"end\n">>]}],
            [],[],[]}
2> 6> bbmustache:compile(Template, #{}, [raise_on_context_miss]).
** exception error: {context_missing,{file_not_found,<<"does_not_exist_template">>}}
     in function  bbmustache:compile_impl/4 (/Users/skyplace/Documents/bbmustache/_build/dev/lib/bbmustache/src/bbmustache.erl, line 234)
     in call from bbmustache:compile_impl/4 (/Users/skyplace/Documents/bbmustache/_build/dev/lib/bbmustache/src/bbmustache.erl, line 239)
     in call from bbmustache:compile/3 (/Users/skyplace/Documents/bbmustache/_build/dev/lib/bbmustache/src/bbmustache.erl, line 187)
```