### PR TITLE
Treat nil and empty binaries as false in conditions

### DIFF
--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -289,6 +289,10 @@ compile_impl([{'#', Keys, Tags, Source} | T], Data, Result, State) ->
                                              Result, Value), State);
       _ when Value =:= false ->
             compile_impl(T, Data, Result, State);
+      _ when Value =:= nil ->
+            compile_impl(T, Data, Result, State);
+      _ when Value =:= "" ->
+            compile_impl(T, Data, Result, State);
       _ when is_function(Value, 2) ->
             Ret = Value(Source, fun(Text) -> render(Text, Data, State#?MODULE.options) end),
             compile_impl(T, Data, ?ADD(Ret, Result), State);
@@ -297,7 +301,7 @@ compile_impl([{'#', Keys, Tags, Source} | T], Data, Result, State) ->
     end;
 compile_impl([{'^', Keys, Tags} | T], Data, Result, State) ->
     Value = get_data_recursive(Keys, Data, false, State),
-    case Value =:= [] orelse Value =:= false of
+    case Value =:= [] orelse Value =:= false orelse Value =:= nil orelse Value =:= "" of
         true  -> compile_impl(T, Data, compile_impl(Tags, Data, Result, State), State);
         false -> compile_impl(T, Data, Result, State)
     end;

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -291,7 +291,7 @@ compile_impl([{'#', Keys, Tags, Source} | T], Data, Result, State) ->
             compile_impl(T, Data, Result, State);
       _ when Value =:= nil ->
             compile_impl(T, Data, Result, State);
-      _ when Value =:= "" ->
+      _ when Value =:= <<"">> ->
             compile_impl(T, Data, Result, State);
       _ when is_function(Value, 2) ->
             Ret = Value(Source, fun(Text) -> render(Text, Data, State#?MODULE.options) end),

--- a/test/bbmustache_tests.erl
+++ b/test/bbmustache_tests.erl
@@ -215,7 +215,23 @@ context_stack_test_() ->
       ?_assertEqual(<<"">>,
                     bbmustache:render(<<"{{#parent}}aaa{{parent.child}}bbb{{/parent}}">>,
                                       [{"parent", []}],
-                                      [raise_on_context_miss]))}
+                                      [raise_on_context_miss]))},
+     {"It hides content in # tag that is specified as \"\"",
+      ?_assertEqual(<<"">>,
+                    bbmustache:render(<<"{{#content}}hello world{{/content}}">>,
+                                      [{"content", ""}]))},
+     {"It hides content in # tag that is specified as \"\"",
+      ?_assertEqual(<<"">>,
+                    bbmustache:render(<<"{{#content}}hello world{{/content}}">>,
+                                      [{"content", nil}]))},
+     {"It shows content in ^ tag that is specified as \"\"",
+      ?_assertEqual(<<"hello world">>,
+                    bbmustache:render(<<"{{^content}}hello world{{/content}}">>,
+                                      [{"content", ""}]))},
+     {"It shows content in ^ tag that is specified as \"\"",
+      ?_assertEqual(<<"hello world">>,
+                    bbmustache:render(<<"{{^content}}hello world{{/content}}">>,
+                                      [{"content", nil}]))}
     ].
 
 escape_fun_test_() ->


### PR DESCRIPTION
First, thanks for creating this library! Second, please forgive me -- I work mainly with Elixir, and this is the first time I've written any Erlang. If you have any suggestions on how I can improve this, please let me know.

---

Most Mustache implementations that I've used in other languages treat `""` and `nil`/`null`/`undefined` the same as `false` in conditions. For example, if you plug this template into https://mustache.github.io/#demo

```
{{#test1}}
aaa
{{/test1}}
{{^test1}}
bbb
{{/test1}}

{{#test2}}
ccc
{{/test2}}
{{^test2}}
ddd
{{/test2}}
```

and put `{"test1": "", "test2": null}` into the JSON field, it should render this:

```
bbb
ddd
```