### PR TITLE
mustache specification v1.2.1 compatible

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,8 +3,8 @@
 
 |Library|Time  |
 |:------|:-----|
-|bbmustache | 39219 |
-|mustache.erl | 677911 |
+|bbmustache | 39122 |
+|mustache.erl | 673416 |
 
 # Check the reference implementation
 :warning: For libraries other than bbmustache, there is a possibility that there is a miss.
@@ -152,9 +152,9 @@ https://github.com/mustache/spec/tree/v1.2.1/specs/sections.yml
 |Null is falsey|:white_check_mark:||
 |Context|:white_check_mark:||
 |Parent contexts|:white_check_mark:||
-|Variable test|||
+|Variable test|:white_check_mark:||
 |List Contexts|:white_check_mark:||
-|Deeply Nested Contexts|||
+|Deeply Nested Contexts|:white_check_mark:||
 |List|:white_check_mark:||
 |Empty List|:white_check_mark:|:white_check_mark:|
 |Doubled|:white_check_mark:|:white_check_mark:|

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,8 +3,8 @@
 
 |Library|Time  |
 |:------|:-----|
-|bbmustache | 36802 |
-|mustache.erl | 666050 |
+|bbmustache | 39219 |
+|mustache.erl | 677911 |
 
 # Check the reference implementation
 :warning: For libraries other than bbmustache, there is a possibility that there is a miss.
@@ -65,9 +65,9 @@ https://github.com/mustache/spec/tree/v1.2.1/specs/interpolation.yml
 |Basic Decimal Interpolation|:white_check_mark:|:white_check_mark:|
 |Triple Mustache Decimal Interpolation|:white_check_mark:|:white_check_mark:|
 |Ampersand Decimal Interpolation|:white_check_mark:|:white_check_mark:|
-|Basic Null Interpolation|||
-|Triple Mustache Null Interpolation|||
-|Ampersand Null Interpolation|||
+|Basic Null Interpolation|:white_check_mark:||
+|Triple Mustache Null Interpolation|:white_check_mark:||
+|Ampersand Null Interpolation|:white_check_mark:||
 |Basic Context Miss Interpolation|:white_check_mark:|:white_check_mark:|
 |Triple Mustache Context Miss Interpolation|:white_check_mark:|:white_check_mark:|
 |Ampersand Context Miss Interpolation|:white_check_mark:|:white_check_mark:|

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,15 +3,15 @@
 
 |Library|Time  |
 |:------|:-----|
-|bbmustache | 44052 |
-|mustache.erl | 682433 |
+|bbmustache | 36567 |
+|mustache.erl | 672254 |
 
 # Check the reference implementation
 :warning: For libraries other than bbmustache, there is a possibility that there is a miss.
 
 
 ## comments
-https://github.com/mustache/spec/tree/v1.1.3/specs/comments.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/comments.yml
 
 |    |bbmustache|mustache.erl|
 |:---|:------------|:------------|
@@ -29,7 +29,7 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/comments.yml
 
 
 ## delimiters
-https://github.com/mustache/spec/tree/v1.1.3/specs/delimiters.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/delimiters.yml
 
 |    |bbmustache|mustache.erl|
 |:---|:------------|:------------|
@@ -50,7 +50,7 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/delimiters.yml
 
 
 ## interpolation
-https://github.com/mustache/spec/tree/v1.1.3/specs/interpolation.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/interpolation.yml
 
 |    |bbmustache|mustache.erl|
 |:---|:------------|:------------|
@@ -65,6 +65,9 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/interpolation.yml
 |Basic Decimal Interpolation|:white_check_mark:|:white_check_mark:|
 |Triple Mustache Decimal Interpolation|:white_check_mark:|:white_check_mark:|
 |Ampersand Decimal Interpolation|:white_check_mark:|:white_check_mark:|
+|Basic Null Interpolation|||
+|Triple Mustache Null Interpolation|||
+|Ampersand Null Interpolation|||
 |Basic Context Miss Interpolation|:white_check_mark:|:white_check_mark:|
 |Triple Mustache Context Miss Interpolation|:white_check_mark:|:white_check_mark:|
 |Ampersand Context Miss Interpolation|:white_check_mark:|:white_check_mark:|
@@ -76,6 +79,11 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/interpolation.yml
 |Dotted Names - Broken Chain Resolution|:white_check_mark:||
 |Dotted Names - Initial Resolution|:white_check_mark:||
 |Dotted Names - Context Precedence|:white_check_mark:||
+|Implicit Iterators - Basic Interpolation|:white_check_mark:||
+|Implicit Iterators - HTML Escaping|:white_check_mark:||
+|Implicit Iterators - Triple Mustache|:white_check_mark:||
+|Implicit Iterators - Ampersand|:white_check_mark:||
+|Implicit Iterators - Basic Integer Interpolation|:white_check_mark:||
 |Interpolation - Surrounding Whitespace|:white_check_mark:|:white_check_mark:|
 |Triple Mustache - Surrounding Whitespace|:white_check_mark:|:white_check_mark:|
 |Ampersand - Surrounding Whitespace|:white_check_mark:|:white_check_mark:|
@@ -88,12 +96,13 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/interpolation.yml
 
 
 ## inverted
-https://github.com/mustache/spec/tree/v1.1.3/specs/inverted.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/inverted.yml
 
 |    |bbmustache|mustache.erl|
 |:---|:------------|:------------|
 |Falsey|:white_check_mark:|:white_check_mark:|
 |Truthy|:white_check_mark:|:white_check_mark:|
+|Null is falsey|||
 |Context|:white_check_mark:|:white_check_mark:|
 |List|:white_check_mark:|:white_check_mark:|
 |Empty List|:white_check_mark:|:white_check_mark:|
@@ -116,7 +125,7 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/inverted.yml
 
 
 ## partials
-https://github.com/mustache/spec/tree/v1.1.3/specs/partials.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/partials.yml
 
 |    |bbmustache|mustache.erl|
 |:---|:------------|:------------|
@@ -134,14 +143,18 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/partials.yml
 
 
 ## sections
-https://github.com/mustache/spec/tree/v1.1.3/specs/sections.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/sections.yml
 
 |    |bbmustache|mustache.erl|
 |:---|:------------|:------------|
 |Truthy|:white_check_mark:|:white_check_mark:|
 |Falsey|:white_check_mark:|:white_check_mark:|
+|Null is falsey|||
 |Context|:white_check_mark:||
-|Deeply Nested Contexts|:white_check_mark:||
+|Parent contexts|:white_check_mark:||
+|Variable test|||
+|List Contexts|:white_check_mark:||
+|Deeply Nested Contexts|||
 |List|:white_check_mark:||
 |Empty List|:white_check_mark:|:white_check_mark:|
 |Doubled|:white_check_mark:|:white_check_mark:|
@@ -166,8 +179,36 @@ https://github.com/mustache/spec/tree/v1.1.3/specs/sections.yml
 |Padding|:white_check_mark:|:white_check_mark:|
 
 
+## ~inheritance
+https://github.com/mustache/spec/tree/v1.2.1/specs/~inheritance.yml
+
+|    |bbmustache|mustache.erl|
+|:---|:------------|:------------|
+|Default|||
+|Variable|||
+|Triple Mustache|||
+|Sections|||
+|Negative Sections|||
+|Mustache Injection|||
+|Inherit|||
+|Overridden content|||
+|Data does not override block|||
+|Data does not override block default|||
+|Overridden parent|||
+|Two overridden parents|||
+|Override parent with newlines|||
+|Inherit indentation|||
+|Only one override|||
+|Parent template|||
+|Recursion|||
+|Multi-level inheritance|||
+|Multi-level inheritance, no sub child|||
+|Text inside parent|||
+|Text inside parent|||
+
+
 ## ~lambdas
-https://github.com/mustache/spec/tree/v1.1.3/specs/~lambdas.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/~lambdas.yml
 
 |    |bbmustache|mustache.erl|
 |:---|:------------|:------------|

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,8 +3,8 @@
 
 |Library|Time  |
 |:------|:-----|
-|bbmustache | 36567 |
-|mustache.erl | 672254 |
+|bbmustache | 36802 |
+|mustache.erl | 666050 |
 
 # Check the reference implementation
 :warning: For libraries other than bbmustache, there is a possibility that there is a miss.
@@ -102,7 +102,7 @@ https://github.com/mustache/spec/tree/v1.2.1/specs/inverted.yml
 |:---|:------------|:------------|
 |Falsey|:white_check_mark:|:white_check_mark:|
 |Truthy|:white_check_mark:|:white_check_mark:|
-|Null is falsey|||
+|Null is falsey|:white_check_mark:||
 |Context|:white_check_mark:|:white_check_mark:|
 |List|:white_check_mark:|:white_check_mark:|
 |Empty List|:white_check_mark:|:white_check_mark:|
@@ -149,7 +149,7 @@ https://github.com/mustache/spec/tree/v1.2.1/specs/sections.yml
 |:---|:------------|:------------|
 |Truthy|:white_check_mark:|:white_check_mark:|
 |Falsey|:white_check_mark:|:white_check_mark:|
-|Null is falsey|||
+|Null is falsey|:white_check_mark:||
 |Context|:white_check_mark:||
 |Parent contexts|:white_check_mark:||
 |Variable test|||

--- a/benchmarks/bench.escript
+++ b/benchmarks/bench.escript
@@ -71,9 +71,13 @@ main2([Test | Tests], Result) ->
 
 spec_test(Render, Assoc) ->
     Data0    = proplists:get_value(<<"data">>, Assoc),
-    Data     = case proplists:get_value(<<"lambda">>, Data0) of
-                   undefined -> Data0;
-                   Lambda    -> [{<<"lambda">>, lambda(Lambda)} | proplists:delete(<<"lambda">>, Data0)]
+    Data     = case is_list(Data0) of
+                   false -> Data0;
+                   true  ->
+                        case proplists:get_value(<<"lambda">>, Data0) of
+                            undefined -> Data0;
+                            Lambda    -> [{<<"lambda">>, lambda(Lambda)} | proplists:delete(<<"lambda">>, Data0)]
+                        end
                end,
     Expected = proplists:get_value(<<"expected">>, Assoc),
     Template = proplists:get_value(<<"template">>, Assoc),

--- a/benchmarks/output.mustache
+++ b/benchmarks/output.mustache
@@ -13,7 +13,7 @@
 {{# spec_files }}
 
 ## {{ spec }}
-https://github.com/mustache/spec/tree/v1.1.3/specs/{{ spec }}.yml
+https://github.com/mustache/spec/tree/v1.2.1/specs/{{ spec }}.yml
 
 |    |{{# libraries }}{{ library }}|{{/ libraries }}
 |:---|{{# libraries }}:------------|{{/ libraries }}

--- a/ct/bbmustache_spec_SUITE.erl
+++ b/ct/bbmustache_spec_SUITE.erl
@@ -20,8 +20,6 @@
                      {"interpolation.json", <<"Basic Null Interpolation">>},
                      {"interpolation.json", <<"Triple Mustache Null Interpolation">>},
                      {"interpolation.json", <<"Ampersand Null Interpolation">>},
-                     {"inverted.json", <<"Null is falsey">>},
-                     {"sections.json", <<"Null is falsey">>},
                      {"sections.json", <<"Variable test">>},
                      {"sections.json", <<"Deeply Nested Contexts">>}
                     ]).

--- a/ct/bbmustache_spec_SUITE.erl
+++ b/ct/bbmustache_spec_SUITE.erl
@@ -17,9 +17,6 @@
                     ]).
 -define(SKIP_CASES, [
                      % e.g. {"name.json", <<"Test Case">>}
-                     {"interpolation.json", <<"Basic Null Interpolation">>},
-                     {"interpolation.json", <<"Triple Mustache Null Interpolation">>},
-                     {"interpolation.json", <<"Ampersand Null Interpolation">>},
                      {"sections.json", <<"Variable test">>},
                      {"sections.json", <<"Deeply Nested Contexts">>}
                     ]).

--- a/ct/bbmustache_spec_SUITE.erl
+++ b/ct/bbmustache_spec_SUITE.erl
@@ -11,9 +11,19 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(SKIP_FILES, [
-                     "~lambdas.json"
+                     % e.g. "name.json"
+                     "~lambdas.json",
+                     "~inheritance.json"
                     ]).
 -define(SKIP_CASES, [
+                     % e.g. {"name.json", <<"Test Case">>}
+                     {"interpolation.json", <<"Basic Null Interpolation">>},
+                     {"interpolation.json", <<"Triple Mustache Null Interpolation">>},
+                     {"interpolation.json", <<"Ampersand Null Interpolation">>},
+                     {"inverted.json", <<"Null is falsey">>},
+                     {"sections.json", <<"Null is falsey">>},
+                     {"sections.json", <<"Variable test">>},
+                     {"sections.json", <<"Deeply Nested Contexts">>}
                     ]).
 
 %%----------------------------------------------------------------------------------------------------------------------

--- a/ct/bbmustache_spec_SUITE.erl
+++ b/ct/bbmustache_spec_SUITE.erl
@@ -17,8 +17,6 @@
                     ]).
 -define(SKIP_CASES, [
                      % e.g. {"name.json", <<"Test Case">>}
-                     {"sections.json", <<"Variable test">>},
-                     {"sections.json", <<"Deeply Nested Contexts">>}
                     ]).
 
 %%----------------------------------------------------------------------------------------------------------------------

--- a/doc/bbmustache.md
+++ b/doc/bbmustache.md
@@ -77,7 +77,7 @@ key() = binary()
 
 In addition, `.` have a special meaning. <br />
 (1) `parent.child` ... find the child in the parent. <br />
-(2) `.` ... It means this. However, the type of correspond is only `[integer() | float() | binary() | string() | atom()]`. Otherwise, the behavior is undefined.
+(2) `.` ... It means current context.
 
 
 

--- a/rebar.config
+++ b/rebar.config
@@ -38,7 +38,7 @@
                     {deps,
                      [
                       {jsone, "1.4.6"},
-                      {mustache_spec, ".*", {git, "git://github.com/soranoba/spec.git", {tag, "v1.1.3-erl"}}}
+                      {mustache_spec, ".*", {git, "git://github.com/soranoba/spec.git", {tag, "v1.2.1-erl"}}}
                      ]},
                     {plugins, [rebar3_raw_deps]}
                    ]},

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -246,12 +246,14 @@ default_value_serializer(Float) when is_float(Float) ->
     %% NOTE: It is the same behaviour as io_lib:format("~p", [Float]), but it is fast than.
     %%       http://www.cs.indiana.edu/~dyb/pubs/FP-Printing-PLDI96.pdf
     io_lib_format:fwrite_g(Float);
-default_value_serializer(Atom) when is_atom(Atom) ->
-    list_to_binary(atom_to_list(Atom));
 default_value_serializer(X) when is_map(X); is_tuple(X) ->
     error(unsupported_term, [X]);
 default_value_serializer(X) ->
-    X.
+    case is_falsy(X) of
+        true                  -> [];
+        false when is_atom(X) -> list_to_binary(atom_to_list(X));
+        false                 -> X
+    end.
 
 %% @doc Default partial file reader
 -spec default_partial_file_reader(binary(), binary()) -> {ok, binary()} | {error, Reason :: term()}.

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -70,23 +70,11 @@
 %%
 %% In addition, `.' have a special meaning. <br />
 %% (1) `parent.child' ... find the child in the parent. <br />
-%% (2) `.' ... It means this. However, the type of correspond is only `[integer() | float() | binary() | string() | atom()]'. Otherwise, the behavior is undefined.
+%% (2) `.' ... It means current context.
 %%
 
 -type source() :: binary().
 %% If you use lamda expressions, the original text is necessary.
-%%
-%% ```
-%% e.g.
-%%   template:
-%%     {{#lamda}}a{{b}}c{{/lamda}}
-%%   parse result:
-%%     {'#', <<"lamda">>, [<<"a">>, {'n', <<"b">>}, <<"c">>], <<"a{{b}}c">>}
-%% '''
-%%
-%% NOTE:
-%%   Since the binary reference is used internally, it is not a capacitively large waste.
-%%   However, the greater the number of tags used, it should use the wasted memory.
 
 -type tag()    :: {n,   [key()]}
                 | {'&', [key()]}
@@ -94,6 +82,19 @@
                 | {'^', [key()], [tag()]}
                 | {'>', key(), Indent :: source()}
                 | binary(). % plain text
+%% Tag is the internal data structure of the result of parsing the mustache template.
+%%
+%% ```
+%% e.g.
+%%   template:
+%%     {{#lamda}}a{{b}}c{{/lamda}}
+%%   parse result:
+%%     {'#', [<<"lamda">>], [<<"a">>, {'n', <<"b">>}, <<"c">>], <<"a{{b}}c">>}
+%% '''
+%%
+%% NOTE:
+%%   Since the binary reference is used internally, it is not a capacitively large waste.
+%%   However, the greater the number of tags used, it uses the wasted memory.
 
 -record(?MODULE,
         {


### PR DESCRIPTION
- Modified the implementation to pass the test cases added in v1.2.0 or v1.2.1.
- [Inheritence](https://github.com/mustache/spec/blob/v1.2.1/specs/~inheritance.yml) added in v1.2.0 is not currently supported.
