### PR TITLE
Allow printing false.

### DIFF
--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -249,12 +249,12 @@ default_value_serializer(Float) when is_float(Float) ->
     io_lib_format:fwrite_g(Float);
 default_value_serializer(X) when is_map(X); is_tuple(X) ->
     error(unsupported_term, [X]);
+default_value_serializer(X) when X =:= null; X =:= nil ->
+    [];
+default_value_serializer(X) when is_atom(X) ->
+    list_to_binary(atom_to_list(X));
 default_value_serializer(X) ->
-    case is_falsy(X) of
-        true                  -> [];
-        false when is_atom(X) -> list_to_binary(atom_to_list(X));
-        false                 -> X
-    end.
+    X.
 
 %% @doc Default partial file reader
 -spec default_partial_file_reader(binary(), binary()) -> {ok, binary()} | {error, Reason :: term()}.

--- a/test/bbmustache_tests.erl
+++ b/test/bbmustache_tests.erl
@@ -205,6 +205,16 @@ raise_on_context_miss_test_() ->
                                       [raise_on_context_miss]))}
     ].
 
+falsy_value_test_() ->
+    [
+      {"It prints false when value is false",
+       ?_assertEqual(<<"false">>, bbmustache:render(<<"{{a}}">>, [{"a", false}]))},
+      {"It prints an empty string when value is null",
+        ?_assertEqual(<<"">>, bbmustache:render(<<"{{a}}">>, [{"a", null}]))},
+      {"It prints an empty string when value is nil",
+        ?_assertEqual(<<"">>, bbmustache:render(<<"{{a}}">>, [{"a", nil}]))}
+    ].
+
 context_stack_test_() ->
     [
      {"It can use the key which parent is not a dictionary (resolve #22)",


### PR DESCRIPTION
No longer outputs null in v1.12.0.
false was also no longer outputs, but it is by mistake.

The PR allows to output false (null cannot output).