### PR TITLE
Accept a function as key_type

### DIFF
--- a/doc/bbmustache.md
+++ b/doc/bbmustache.md
@@ -57,12 +57,12 @@ By specifying options, the type are greatly relaxed and equal to `term/0`.
 
 
 <pre><code>
-data_key() = atom() | binary() | string()
+data_key() = atom() | binary() | string() | fun((binary()) -&gt; term())
 </code></pre>
 
  You can choose one from these as the type of key in [`recursive_data/0`](#recursive_data-0).
 The default is `string/0`.
-If you want to change this, you need to specify `key_type` in [`compile_option/0`](#compile_option-0).
+If you want to change this, you need to specify `key_type` in [`compile_option/0`](#compile_option-0). To customize the how tag is converted into a key in [`recursive_data/0`](#recursive_data-0) a 1-arity function can be passed that accepts the key name from the template and converts it to the appropriate key in [`recursive_data/0`](#recursive_data-0).
 
 
 

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -156,10 +156,10 @@
 %% @see render/2
 %% @see compile/2
 
--type data_key() :: atom() | binary() | string().
+-type data_key() :: atom() | binary() | string() | fun((binary()) -> term()).
 %% You can choose one from these as the type of key in {@link recursive_data/0}.
 %% The default is `string/0'.
-%% If you want to change this, you need to specify `key_type' in {@link compile_option/0}.
+%% If you want to change this, you need to specify `key_type' in {@link compile_option/0}. To customize the how tag is converted into a key in {@link recursive_data/0} a 1-arity function can be passed that accepts the key name from the template and converts it to the appropriate key in {@link recursive_data/0}.
 
 -ifdef(namespaced_types).
 -type recursive_data() :: #{data_key() => term()} | [{data_key(), term()}].
@@ -638,7 +638,8 @@ convert_keytype(KeyBin, #?MODULE{options = Options}) ->
                 _:_ -> <<" ">> % It is not always present in data/0
             end;
         string -> binary_to_list(KeyBin);
-        binary -> KeyBin
+        binary -> KeyBin;
+        Function when is_function(Function, 1) -> Function(KeyBin)
     end.
 
 %% @doc fetch the value of the specified `Keys' from {@link data/0}

--- a/test/bbmustache_tests.erl
+++ b/test/bbmustache_tests.erl
@@ -141,7 +141,7 @@ top_level_context_render_test_() ->
       ?_assertEqual(<<"yes">>, bbmustache:render(<<"{{.}}">>, #{"a" => "1"}, [{value_serializer, fun(#{"a" := "1"}) -> <<"yes">> end}]))}
     ].
 
-atom_and_binary_key_test_() ->
+atom_binary_and_function_key_test_() ->
     [
      {"atom key",
       fun() ->
@@ -157,6 +157,13 @@ atom_and_binary_key_test_() ->
               ?assertEqual(<<"<b>Willy is awesome.</b>">>,
                            bbmustache:render(<<"{{#wrapped}}{{name}} is awesome.{{dummy}}{{/wrapped}}">>,
                                              [{<<"name">>, "Willy"}, {<<"wrapped">>, F}], [{key_type, binary}]))
+      end},
+     {"custom key function",
+      fun() ->
+              F = fun(Text, Render) -> ["<b>", Render(Text), "</b>"] end,
+              ?assertEqual(<<"<b>Willy is awesome.</b>">>,
+                           bbmustache:render(<<"{{#WRAPPED}}{{NAME}} is awesome.{{DUMMY}}{{/WRAPPED}}">>,
+                                             [{<<"name">>, "Willy"}, {<<"wrapped">>, F}], [{key_type, fun(Key) -> string:lowercase(Key) end}]))
       end}
     ].
 


### PR DESCRIPTION
I'm having issues in my application where the tags in my mustache template are not being input with the proper case. This PR allows a function to be passed as a `key_type`, giving me an opportunity to inject an anonymous function that downcases the key before looking it up in the data.

Please let me know if there's a better way this should be handled. This is also my first Erlang PR (coming from Elixir), so if there's something that doesn't look quite right, I'd be happy to find out and fix it.