### PR TITLE
Add the list-variables function

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ hoge
 Data files (-d) support a single assoc list, a single map, and [consult](https://erlang.org/doc/man/file.html#consult-1) format.<br>
 Note: the behind term has a high priority in all cases. it is a result of supporting to allow for embedding relative file paths as in [config](http://erlang.org/doc/man/config.html).
 
+
+### Listing variables inside a template
+
+In order to provide more feedback to the user/instrumenting code - the library
+has a "list_variables(Template)" function, which can list the variables inside
+the template:
+
+```
+$ rebar3 shell
+1> T = bbmustache:parse_file(<<"./example/deps.template">>).
+2> bbmustache:list_variables(T).
+[<<"deps">>,<<"last?">>,<<"name">>,<<"version">>]
+```
+
+
 ### More information
 - For the alias of mustache, Please refer to [ManPage](http://mustache.github.io/mustache.5.html) and [Specification](https://github.com/mustache/spec)
 - For the options of this library, please see [doc](doc)

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -22,7 +22,8 @@
          compile/2,
          compile/3,
          default_value_serializer/1,
-         default_partial_file_reader/2
+         default_partial_file_reader/2,
+         list_variables/1
         ]).
 
 -ifdef(bbmustache_escriptize).
@@ -255,6 +256,18 @@ default_value_serializer(X) when is_atom(X) ->
     list_to_binary(atom_to_list(X));
 default_value_serializer(X) ->
     X.
+
+
+%% @doc Returns a list of all the variables which were found in the Template
+list_variables({?MODULE,StmtList,_,_,_,_}) -> lists:usort(compile_varlist(StmtList,[])).
+compile_varlist([],Acc) ->  Acc;
+compile_varlist([Str|T],Acc) when is_bitstring(Str)-> compile_varlist(T,Acc);
+compile_varlist([{_Atom,[Key]}|T],Acc) -> compile_varlist(T,[Key|Acc]);
+compile_varlist([{_Atom,[Key],_Indents}|T],Acc) -> compile_varlist(T,[Key|Acc]);
+compile_varlist([{_Atom,[Key],More,_TxtFormat}|T],Acc) ->
+  RecurAcc = compile_varlist(More,Acc),
+  compile_varlist(T,[Key|RecurAcc]).
+
 
 %% @doc Default partial file reader
 -spec default_partial_file_reader(binary(), binary()) -> {ok, binary()} | {error, Reason :: term()}.


### PR DESCRIPTION
This function parses the template and returns a list of variable names.

See the README.md file for an example.

Hopefully this is a useful addition to bbmustache.

Kind regards,

Fabian


