### PR TITLE
Fix Github deprecated git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A logic-less templates.
 ### Quick start
 
 ```bash
-$ git clone git://github.com/soranoba/bbmustache.git
+$ git clone https://github.com/soranoba/bbmustache.git
 $ cd bbmustache
 $ make start
 Erlang/OTP 17 [erts-6.3] [source-f9282c6] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:true]
@@ -39,7 +39,7 @@ Add the following settings.
 
 {deps,
   [
-   {bbmustache, ".*", {git, "git://github.com/soranoba/bbmustache.git", {branch, "master"}}}
+   {bbmustache, ".*", {git, "https://github.com/soranoba/bbmustache.git", {branch, "master"}}}
   ]}.
 
 %% rebar3 (rebar.config)

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
                     {deps,
                      [
                       {jsone, "1.4.6"},
-                      {mustache_spec, ".*", {git, "git://github.com/soranoba/spec.git", {tag, "v1.2.2-erl"}}}
+                      {mustache_spec, ".*", {git, "https://github.com/soranoba/spec.git", {tag, "v1.2.2-erl"}}}
                      ]},
                     {plugins, [rebar3_raw_deps]}
                    ]},
@@ -54,12 +54,12 @@
                   ]},
             {doc, [{deps,
                     [
-                     {edown, ".*", {git, "git://github.com/uwiger/edown.git", {tag, "0.8.3"}}}
+                     {edown, ".*", {git, "https://github.com/uwiger/edown.git", {tag, "0.8.3"}}}
                     ]}
                   ]},
             {bench, [{deps,
                       [
-                       {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl", {tag, "v0.1.1"}}}
+                       {mustache, ".*", {git, "https://github.com/mojombo/mustache.erl", {tag, "v0.1.1"}}}
                       ]}
                     ]}
            ]}.


### PR DESCRIPTION
Git URLs starting with `git://` are deprecated due to being
unauthenticated and they are a security risk. See the announcement
on the [Github blog](https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting).