### PR TITLE
Enable maps/unicode support

### DIFF
--- a/ct/bbmustache_SUITE.erl
+++ b/ct/bbmustache_SUITE.erl
@@ -12,13 +12,13 @@
          variables_ct/1, sections_ct1/1, sections_ct2/1, sections_ct3/1, sections_ct4/1,
          lambdas_ct/1, comments_ct/1, partials_ct/1, delimiter_ct/1, dot_ct/1, dot_unescape_ct/1,
          indent_partials_ct/1, not_found_partials_ct1/1, not_found_partials_ct2/1, not_found_partials_ct3/1,
-         context_stack_ct/1, context_stack_ct2/1, partial_custom_reader_ct/1,
+         context_stack_ct/1, context_stack_ct2/1, nested_context_ct/1, partial_custom_reader_ct/1,
          unicode_render_ct/1
         ]).
 -define(ALL_TEST, [variables_ct, sections_ct1, sections_ct2, sections_ct3, sections_ct4,
                    lambdas_ct, comments_ct, partials_ct, delimiter_ct, dot_ct, dot_unescape_ct,
                    indent_partials_ct, not_found_partials_ct1, not_found_partials_ct2, not_found_partials_ct3,
-                   context_stack_ct, context_stack_ct2, partial_custom_reader_ct, unicode_render_ct]).
+                   context_stack_ct, context_stack_ct2, nested_context_ct, partial_custom_reader_ct, unicode_render_ct]).
 
 -define(config2, proplists:get_value).
 -define(debug(X), begin io:format("~p", [X]), X end).
@@ -197,6 +197,19 @@ context_stack_ct2(Config) ->
             {"items", [[{"item", 1}], [{"item", 2}], [{"item", 3}]]},
             {"a", [{"b", ["A", "B", "C"]}]}
            ],
+    ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
+
+nested_context_ct(Config) ->
+    Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"nested_context.mustache">>])),
+    {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"nested_context.result">>])),
+
+    Data = [
+        {"list", ["ELEM 1", "ELEM 2", "ELEM 3"]},
+        {"util", [
+            {"lower", fun(Text, Render) -> string:to_lower(binary_to_list(Render(Text))) end},
+            {"titlecase", fun(Text, Render) -> string:titlecase(binary_to_list(Render(Text))) end}
+        ]}
+    ],
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
 
 partial_custom_reader_ct(Config) ->

--- a/ct/bbmustache_SUITE.erl
+++ b/ct/bbmustache_SUITE.erl
@@ -10,13 +10,13 @@
          init_per_group/2, end_per_group/2,
 
          variables_ct/1, sections_ct1/1, sections_ct2/1, sections_ct3/1, sections_ct4/1,
-         lambdas_ct/1, comments_ct/1, partials_ct/1, delimiter_ct/1, dot_ct/1, dot_unescape_ct/1,
+         lists_ct/1, lambdas_ct/1, comments_ct/1, partials_ct/1, delimiter_ct/1, dot_ct/1, dot_unescape_ct/1,
          indent_partials_ct/1, not_found_partials_ct1/1, not_found_partials_ct2/1, not_found_partials_ct3/1,
          context_stack_ct/1, context_stack_ct2/1, nested_context_ct/1, partial_custom_reader_ct/1,
          unicode_render_ct/1
         ]).
 -define(ALL_TEST, [variables_ct, sections_ct1, sections_ct2, sections_ct3, sections_ct4,
-                   lambdas_ct, comments_ct, partials_ct, delimiter_ct, dot_ct, dot_unescape_ct,
+                   lists_ct, lambdas_ct, comments_ct, partials_ct, delimiter_ct, dot_ct, dot_unescape_ct,
                    indent_partials_ct, not_found_partials_ct1, not_found_partials_ct2, not_found_partials_ct3,
                    context_stack_ct, context_stack_ct2, nested_context_ct, partial_custom_reader_ct, unicode_render_ct]).
 
@@ -113,6 +113,13 @@ sections_ct4(Config) ->
     {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"invarted.result">>])),
 
     Data = [{"repo", []}],
+    ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
+
+lists_ct(Config) ->
+    Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"list_attributes.mustache">>])),
+    {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"list_attributes.result">>])),
+
+    Data = [{"list1", [1, 2, 3]}, {"list2", []}],
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data)), ?config2(options, Config, []))).
 
 lambdas_ct(Config) ->

--- a/ct/bbmustache_SUITE.erl
+++ b/ct/bbmustache_SUITE.erl
@@ -226,7 +226,6 @@ partial_custom_reader_ct(Config) ->
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))([])),
                                           ?config2(options, Config, []) ++ [{partial_file_reader, fun(_, Key) -> Key end}])).
 
--ifdef(unicode_supported).
 unicode_render_ct(Config) ->
     Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"unicode.mustache">>])),
     {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"unicode.result">>])),
@@ -248,17 +247,6 @@ unicode_render_ct(Config) ->
             {"name", 'まだない'}
            ],
     ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data3)), ?config2(options, Config, []))).
--else.
-unicode_render_ct(Config) ->
-    Template   = bbmustache:parse_file(filename:join([?config(data_dir, Config), <<"unicode.mustache">>])),
-    {ok, File} = file:read_file(filename:join([?config(data_dir, Config), <<"unicode.result">>])),
-
-    Data1 = [
-            {"whoami", "猫"},
-            {"name", "まだない"}
-           ],
-    ?assertEqual(File, bbmustache:compile(Template, ?debug((?config(data_conv, Config))(Data1)), ?config2(options, Config, []))).
--endif.
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Internal Functions

--- a/ct/bbmustache_SUITE_data/list_attributes.mustache
+++ b/ct/bbmustache_SUITE_data/list_attributes.mustache
@@ -1,0 +1,19 @@
+List 1 length: {{ list1.length }}
+List 1 empty: {{ list1.empty }}
+
+List 2 length: {{ list2.length }}
+List 2 empty: {{ list2.empty }}
+
+{{# list1.empty }}
+Should not show
+{{/ list1.empty }}
+{{^ list1.empty }}
+List 1 is not empty
+{{/ list1.empty }}
+
+{{# list2.empty }}
+List 2 is empty
+{{/ list2.empty }}
+{{^ list2.empty }}
+Should now show
+{{/ list2.empty }}

--- a/ct/bbmustache_SUITE_data/list_attributes.result
+++ b/ct/bbmustache_SUITE_data/list_attributes.result
@@ -1,0 +1,9 @@
+List 1 length: 3
+List 1 empty: false
+
+List 2 length: 0
+List 2 empty: true
+
+List 1 is not empty
+
+List 2 is empty

--- a/ct/bbmustache_SUITE_data/nested_context.mustache
+++ b/ct/bbmustache_SUITE_data/nested_context.mustache
@@ -1,0 +1,7 @@
+{{# list }}
+{{# util.titlecase }}
+{{# util.lower }}
+{{ . }}
+{{/ util.lower }}
+{{/ util.titlecase }}
+{{/ list }}

--- a/ct/bbmustache_SUITE_data/nested_context.result
+++ b/ct/bbmustache_SUITE_data/nested_context.result
@@ -1,0 +1,3 @@
+Elem 1
+Elem 2
+Elem 3

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,6 @@
 %% vim: set filetype=erlang : -*- erlang -*-
 
 {erl_opts, [
-            {platform_define, "^[0-9]+", namespaced_types},
-            {platform_define, "^20", unicode_supported},
             warnings_as_errors,
             warn_export_all,
             warn_untyped_record

--- a/src/bbmustache.erl
+++ b/src/bbmustache.erl
@@ -162,11 +162,7 @@
 %% The default is `string/0'.
 %% If you want to change this, you need to specify `key_type' in {@link compile_option/0}.
 
--ifdef(namespaced_types).
 -type recursive_data() :: #{data_key() => term()} | [{data_key(), term()}].
--else.
--type recursive_data() :: [{data_key(), term()}].
--endif.
 %% It is a part of {@link data/0} that can have child elements.
 
 -type endtag()    :: {endtag, {state(), [key()], LastTagSize :: non_neg_integer(), Rest :: binary(), Result :: [tag()]}}.
@@ -695,7 +691,6 @@ get_data_recursive_impl([Key | RestKey] = Keys, Data, #?MODULE{context_stack = S
 
 %% @doc find the value of the specified key from {@link recursive_data/0}
 -spec find_data(data_key(), recursive_data() | term()) -> {ok, Value :: term()} | error.
--ifdef(namespaced_types).
 find_data(Key, Map) when is_map(Map) ->
     maps:find(Key, Map);
 find_data(Key, AssocList) when is_list(AssocList) ->
@@ -705,26 +700,12 @@ find_data(Key, AssocList) when is_list(AssocList) ->
     end;
 find_data(_, _) ->
     error.
--else.
-find_data(Key, AssocList) ->
-    case proplists:lookup(Key, AssocList) of
-        none   -> error;
-        {_, V} -> {ok, V}
-    end;
-find_data(_, _) ->
-    error.
--endif.
 
 %% @doc When the value is {@link recursive_data/0}, it returns true. Otherwise it returns false.
 -spec is_recursive_data(recursive_data() | term()) -> boolean().
--ifdef(namespaced_types).
 is_recursive_data([Tuple | _]) when is_tuple(Tuple) -> true;
 is_recursive_data(V) when is_map(V)                 -> true;
 is_recursive_data(_)                                -> false.
--else.
-is_recursive_data([Tuple | _]) when is_tuple(Tuple) -> true;
-is_recursive_data(_)                                -> false.
--endif.
 
 %%----------------------------------------------------------------------------------------------------------------------
 %% Escriptize


### PR DESCRIPTION
The given regexes in erl_opts do not define the macros in OTP 25+, preventing the usage of maps and unicode support.